### PR TITLE
BrokerID and JMX monitoring information displays for each kafka broker

### DIFF
--- a/kafka-eagle-core/src/main/java/org/smartloli/kafka/eagle/core/factory/KafkaService.java
+++ b/kafka-eagle-core/src/main/java/org/smartloli/kafka/eagle/core/factory/KafkaService.java
@@ -17,6 +17,7 @@
  */
 package org.smartloli.kafka.eagle.core.factory;
 
+import kafka.zk.KafkaZkClient;
 import org.apache.kafka.common.TopicPartition;
 import org.smartloli.kafka.eagle.common.protocol.*;
 
@@ -60,6 +61,11 @@ public interface KafkaService {
      * Get all broker list from zookeeper.
      */
     public List<BrokersInfo> getAllBrokersInfo(String clusterAlias);
+
+    /**
+     * Get broker list for given brokerIds from zookeeper.
+     */
+    public List<BrokersInfo> getBrokersInfoByIds(String clusterAlias, KafkaZkClient zkc, List<String> brokerIds);
 
     /**
      * Get broker host info from ids.

--- a/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/controller/ClusterController.java
+++ b/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/controller/ClusterController.java
@@ -128,6 +128,7 @@ public class ClusterController {
             if (search.length() > 0 && search.equals(cluster.getString("host"))) {
                 JSONObject obj = new JSONObject();
                 obj.put("id", cluster.getInteger("id"));
+                obj.put("brokerId", "<a href='/metrics/brokers/" + cluster.getString("ids") + "/' target='_blank'>" + cluster.getString("ids") + "</a>");
                 obj.put("port", cluster.getInteger("port"));
                 obj.put("ip", cluster.getString("host"));
                 if ("kafka".equals(type)) {
@@ -180,6 +181,7 @@ public class ClusterController {
                 if (offset < (iDisplayLength + iDisplayStart) && offset >= iDisplayStart) {
                     JSONObject obj = new JSONObject();
                     obj.put("id", cluster.getInteger("id"));
+                    obj.put("brokerId", "<a href='/metrics/brokers/" + cluster.getString("ids") + "/' target='_blank'>" + cluster.getString("ids") + "</a>");
                     obj.put("port", cluster.getInteger("port"));
                     obj.put("ip", cluster.getString("host"));
                     if ("kafka".equals(type)) {

--- a/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/controller/ClusterController.java
+++ b/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/controller/ClusterController.java
@@ -128,10 +128,10 @@ public class ClusterController {
             if (search.length() > 0 && search.equals(cluster.getString("host"))) {
                 JSONObject obj = new JSONObject();
                 obj.put("id", cluster.getInteger("id"));
-                obj.put("brokerId", "<a href='/metrics/brokers/" + cluster.getString("ids") + "/' target='_blank'>" + cluster.getString("ids") + "</a>");
                 obj.put("port", cluster.getInteger("port"));
                 obj.put("ip", cluster.getString("host"));
                 if ("kafka".equals(type)) {
+                    obj.put("brokerId", "<a href='/metrics/brokers/" + cluster.getString("ids") + "/' target='_blank'>" + cluster.getString("ids") + "</a>");
                     obj.put("jmxPort", cluster.getInteger("jmxPort"));
                     obj.put("memory", clusterService.getUsedMemory(clusterAlias, cluster.getString("host"), cluster.getInteger("jmxPort")));
                     obj.put("cpu", clusterService.getUsedCpu(clusterAlias, cluster.getString("host"), cluster.getInteger("jmxPort")));
@@ -181,10 +181,10 @@ public class ClusterController {
                 if (offset < (iDisplayLength + iDisplayStart) && offset >= iDisplayStart) {
                     JSONObject obj = new JSONObject();
                     obj.put("id", cluster.getInteger("id"));
-                    obj.put("brokerId", "<a href='/metrics/brokers/" + cluster.getString("ids") + "/' target='_blank'>" + cluster.getString("ids") + "</a>");
                     obj.put("port", cluster.getInteger("port"));
                     obj.put("ip", cluster.getString("host"));
                     if ("kafka".equals(type)) {
+                        obj.put("brokerId", "<a href='/metrics/brokers/" + cluster.getString("ids") + "/' target='_blank'>" + cluster.getString("ids") + "</a>");
                         obj.put("jmxPort", cluster.getInteger("jmxPort"));
                         obj.put("memory", clusterService.getUsedMemory(clusterAlias, cluster.getString("host"), cluster.getInteger("jmxPort")));
                         obj.put("cpu", clusterService.getUsedCpu(clusterAlias, cluster.getString("host"), cluster.getInteger("jmxPort")));

--- a/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/controller/MetricsController.java
+++ b/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/controller/MetricsController.java
@@ -18,6 +18,7 @@
 package org.smartloli.kafka.eagle.web.controller;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,6 +31,7 @@ import org.smartloli.kafka.eagle.common.util.KConstants;
 import org.smartloli.kafka.eagle.web.service.MetricsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
@@ -77,6 +79,37 @@ public class MetricsController {
 		try {
 			String clusterAlias = session.getAttribute(KConstants.SessionAlias.CLUSTER_ALIAS).toString();
 			String target = metricsService.getAllBrokersMBean(clusterAlias);
+
+			byte[] output = target.getBytes();
+			BaseController.response(output, response);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+		}
+	}
+
+	/**
+	 * Broker data viewer.
+	 */
+	@RequestMapping(value = "/metrics/brokers/{brokerId}/", method = RequestMethod.GET)
+	public ModelAndView topicMetaView(@PathVariable("brokerId") String brokerId, HttpServletRequest request) {
+		ModelAndView mav = new ModelAndView();
+		HttpSession session = request.getSession();
+		String clusterAlias = session.getAttribute(KConstants.SessionAlias.CLUSTER_ALIAS).toString();
+		if (metricsService.hasBrokerId(clusterAlias, brokerId)) {
+			mav.setViewName("/metrics/brokersIds");
+		} else {
+			mav.setViewName("/error/404");
+		}
+
+		return mav;
+	}
+
+	/** Get broker data by ajax. */
+	@RequestMapping(value = "/metrics/brokers/{brokerId}/mbean/ajax", method = RequestMethod.GET)
+	public void brokerAjax(@PathVariable("brokerId") String brokerId, HttpServletResponse response, HttpServletRequest request, HttpSession session) {
+		try {
+			String clusterAlias = session.getAttribute(KConstants.SessionAlias.CLUSTER_ALIAS).toString();
+			String target = metricsService.getBrokersMBeanByIds(clusterAlias, Collections.singletonList(brokerId));
 
 			byte[] output = target.getBytes();
 			BaseController.response(output, response);

--- a/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/service/MetricsService.java
+++ b/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/service/MetricsService.java
@@ -43,6 +43,11 @@ public interface MetricsService {
     public String getAllBrokersMBean(String clusterAlias);
 
     /**
+     * Gets summary monitoring data for given brokerIds.
+     */
+    public String getBrokersMBeanByIds(String clusterAlias, List<String> brokerIds);
+
+    /**
      * Collection statistics data from kafka jmx & insert into table.
      */
     public int insert(List<KpiInfo> kpi);
@@ -136,6 +141,11 @@ public interface MetricsService {
      * Modify kafka connect uri config status(alive or shutdown) by id.
      */
     public int modifyConnectConfigStatusById(ConnectConfigInfo connectConfig);
+
+    /**
+     * If broker exists for a given brokerId
+     */
+    public boolean hasBrokerId(String clusterAlias, String brokerId);
 
 
 }

--- a/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/service/impl/MetricsServiceImpl.java
+++ b/kafka-eagle-web/src/main/java/org/smartloli/kafka/eagle/web/service/impl/MetricsServiceImpl.java
@@ -97,6 +97,15 @@ public class MetricsServiceImpl implements MetricsService {
     }
 
     /**
+     * Gets summary monitoring data for given brokerIds
+     */
+    public String getBrokersMBeanByIds(String clusterAlias, List<String> brokerIds) {
+        List<BrokersInfo> brokersInfoByIds = kafkaService.getBrokersInfoByIds(clusterAlias, null, brokerIds);
+        return getOnlineAllBrokersMBean(clusterAlias, brokersInfoByIds);
+
+    }
+
+    /**
      * Gets summary offline monitoring data for all broker.
      */
     private String getOfflineAllBrokersMBean(Map<String, Object> params) {
@@ -427,6 +436,17 @@ public class MetricsServiceImpl implements MetricsService {
     @Override
     public int modifyConnectConfigStatusById(ConnectConfigInfo connectConfig) {
         return brokerDao.modifyConnectConfigStatusById(connectConfig);
+    }
+
+    @Override
+    public boolean hasBrokerId(String clusterAlias, String brokerId) {
+        List<BrokersInfo> allBrokersInfo = kafkaService.getAllBrokersInfo(clusterAlias);
+        for (BrokersInfo brokerInfo : allBrokersInfo) {
+            if (brokerInfo.getIds().equals(brokerId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/kafka-eagle-web/src/main/webapp/WEB-INF/views/cluster/cluster.jsp
+++ b/kafka-eagle-web/src/main/webapp/WEB-INF/views/cluster/cluster.jsp
@@ -65,6 +65,7 @@
                                         <thead>
                                         <tr>
                                             <th>ID</th>
+                                            <th>BrokerID</th>
                                             <th>IP</th>
                                             <th>Port</th>
                                             <th>JMX Port</th>

--- a/kafka-eagle-web/src/main/webapp/WEB-INF/views/metrics/brokersIds.jsp
+++ b/kafka-eagle-web/src/main/webapp/WEB-INF/views/metrics/brokersIds.jsp
@@ -1,0 +1,66 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+         pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<!DOCTYPE html>
+<html lang="zh">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>Brokers - KafkaEagle</title>
+    <jsp:include page="../public/plus/css.jsp"></jsp:include>
+</head>
+
+<body>
+<jsp:include page="../public/plus/navtop.jsp"></jsp:include>
+<div id="layoutSidenav">
+    <div id="layoutSidenav_nav">
+        <jsp:include page="../public/plus/navbar.jsp"></jsp:include>
+    </div>
+    <div id="layoutSidenav_content">
+        <main>
+            <div class="container-fluid">
+                <h1 class="mt-4">Brokers Metrics</h1>
+                <ol class="breadcrumb mb-4">
+                    <li class="breadcrumb-item"><a href="#">Brokers Metrics</a></li>
+                    <li class="breadcrumb-item active"><a href="/metrics/brokers">Overview</a></li>
+                    <li class="breadcrumb-item active">Broker Id</li>
+                </ol>
+                <div class="alert alert-info alert-dismissable">
+                    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+                    <i class="fas fa-info-circle"></i> <strong>Through JMX to
+                    obtain data, monitor the Kafka client, the production side, the
+                    number of messages, the number of requests, processing time and
+                    other data to visualize performance .</strong>
+                </div>
+                <!-- content body -->
+                <div class="row">
+                    <div class="col-lg-12">
+                        <div class="card mb-4">
+                            <div class="card-header">
+                                <i class="fas fa-server"></i> Kafka Brokers MBean
+                            </div>
+                            <div class="card-body">
+                                <div>
+                                    <table id="kafka_metrics_tab" class="table table-bordered table-hover">
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+        <jsp:include page="../public/plus/footer.jsp"></jsp:include>
+    </div>
+</div>
+</body>
+<jsp:include page="../public/plus/script.jsp">
+    <jsp:param value="main/metrics/brokersIds.js" name="loader"/>
+</jsp:include>
+</html>

--- a/kafka-eagle-web/src/main/webapp/media/js/main/cluster/cluster.js
+++ b/kafka-eagle-web/src/main/webapp/media/js/main/cluster/cluster.js
@@ -10,6 +10,8 @@ $(document).ready(function () {
         "aoColumns": [{
             "mData": 'id'
         }, {
+            "mData": 'brokerId'
+        }, {
             "mData": 'ip'
         }, {
             "mData": 'port'

--- a/kafka-eagle-web/src/main/webapp/media/js/main/metrics/brokersIds.js
+++ b/kafka-eagle-web/src/main/webapp/media/js/main/metrics/brokersIds.js
@@ -1,0 +1,86 @@
+$(document).ready(function() {
+	var url = window.location.href;
+	var brokerId = url.split("brokers/")[1].split("/")[0];
+	console.log("brokerId=" + brokerId)
+	$.ajax({
+		type : 'get',
+		dataType : 'json',
+		url : '/metrics/brokers/' + brokerId + '/mbean/ajax',
+		success : function(datas) {
+			if (datas != null) {
+				$("#kafka_metrics_tab").html("")
+				var thead = "<thead><tr><th>Rate</th><th>Mean</th><th>1 Minute</th><th>5 Minute</th><th>15 Minute</th></tr></thead>";
+				$("#kafka_metrics_tab").append(thead);
+				var tbody = "<tbody>";
+				var msg = brokerMetricData('Messages in /sec', datas.msg);
+
+				msg += brokerMetricData('Bytes in /sec', datas.ins);
+
+				msg += brokerMetricData('Bytes out /sec', datas.out);
+
+				msg += brokerMetricData('Bytes rejected /sec', datas.rejected);
+
+				msg += brokerMetricData('Failed fetch request /sec', datas.fetch);
+
+				msg += brokerMetricData('Failed produce request /sec', datas.produce);
+
+				msg += brokerMetricData('Total fetch requests /sec', datas.total_fetch_requests);
+
+				msg += brokerMetricData('Total produce requests /sec', datas.total_produce_requests);
+
+				msg += brokerMetricData('Replication byte in /sec', datas.replication_bytes_in);
+
+				msg += brokerMetricData('Replication byte out /sec', datas.replication_bytes_out);
+
+				msg += brokerMetricData('Produce message conversions /sec', datas.produce_message_conversions);
+
+				tbody += msg + "</tbody>"
+				$("#kafka_metrics_tab").append(tbody);
+			}
+		}
+	});
+});
+
+function brokerMetricData(field, data) {
+	var tr = '';
+	if (data == null || data == undefined) {
+		return tr;
+	}
+
+	if (field.toUpperCase().indexOf("BYTE") > -1) {
+		tr += "<tr><td>" + field + "</td><td><span class='badge badge-secondary'>" + data.meanRate + "</span></td><td><span class='badge badge-secondary'>" + data.oneMinute + "</span></td><td><span class='badge badge-secondary'>" + data.fiveMinute + "</span></td><td><span class='badge badge-secondary'>" + data.fifteenMinute + "</span></td></tr>";
+	} else {
+		tr += "<tr><td>" + field + "</td><td><span class='badge badge-secondary'>" + revertString2Long(data.meanRate) + "</span></td><td><span class='badge badge-secondary'>" + revertString2Long(data.oneMinute) + "</span></td><td><span class='badge badge-secondary'>" + revertString2Long(data.fiveMinute) + "</span></td><td><span class='badge badge-secondary'>" + revertString2Long(data.fifteenMinute) + "</span></td></tr>";
+	}
+
+	return tr;
+}
+
+// defined byte size
+var KB_IN_BYTES = 1024;
+var MB_IN_BYTES = 1024 * KB_IN_BYTES;
+var GB_IN_BYTES = 1024 * MB_IN_BYTES;
+var TB_IN_BYTES = 1024 * GB_IN_BYTES;
+var PB_IN_BYTES = 1024 * TB_IN_BYTES;
+
+function revertString2Long(dataSource) {
+	var data = dataSource.split("B")[0];
+	 if (data.indexOf("K") > -1) {
+		var value = data.split("K")[0];
+		return (value * KB_IN_BYTES).toFixed(2);
+	} else if (data.indexOf("M") > -1) {
+		var value = data.split("M")[0];
+		return (value * MB_IN_BYTES).toFixed(2);
+	} else if (data.indexOf("G") > -1) {
+		var value = data.split("G")[0];
+		return (value * GB_IN_BYTES).toFixed(2);
+	} else if (data.indexOf("T") > -1) {
+		var value = data.split("T")[0];
+		return (value * TB_IN_BYTES).toFixed(2);
+	} else if (data.indexOf("P") > -1) {
+		var value = data.split("P")[0];
+		return (value * PB_IN_BYTES).toFixed(2);
+	}else{ // Byte
+		return data;
+	}
+}


### PR DESCRIPTION
Based on our experience in operations and maintenance, brokerID is a very important symbol for Kafka.The total number of replicas is distributed by ID across different Kafka brokers.From the existing monitoring of kafka-eagle project, I can't determine which physical node of Kafka the ID corresponds to.The load information of individual Kafka nodes cannot be obtained from existing monitoring, which is not conducive to maintaining the Kafka cluster.Therefore, I added the corresponding broker ID information to the Kafka node monitoring information, and each node can get the JMX information of the node by the broker ID.





