### PR TITLE
support config producer alarm with duration

### DIFF
--- a/efak-web/src/main/java/org/smartloli/kafka/eagle/web/dao/TopicDao.xml
+++ b/efak-web/src/main/java/org/smartloli/kafka/eagle/web/dao/TopicDao.xml
@@ -190,10 +190,10 @@
     </select>
 
     <select id="queryTopicProducerByAlarm" parameterType="map" resultMap="tlogsize">
-        select `cluster`,`topic`,`logsize`,`diffval`,`timespan` from ke_logsize
-        where `cluster`=#{cluster} and `topic`=#{topic}
-        and tm=#{stime} order by `timespan` desc
-        limit 1
+        select sum(`diffval`) as `diffval`,`cluster`,`topic` from
+        (select `cluster`,`topic`,`diffval` from ke_logsize where `cluster`=#{cluster}
+            and `topic`=#{topic} and tm=#{stime} ORDER BY `timespan` desc limit #{duration})
+        as a group by `cluster`,`topic`;
     </select>
 
     <select id="queryProducerHistoryBar" parameterType="map" resultMap="bsbar">

--- a/efak-web/src/main/java/org/smartloli/kafka/eagle/web/quartz/shard/task/alert/ProducerClusterStrategy.java
+++ b/efak-web/src/main/java/org/smartloli/kafka/eagle/web/quartz/shard/task/alert/ProducerClusterStrategy.java
@@ -45,6 +45,17 @@ public class ProducerClusterStrategy implements ClusterStrategy {
         JSONObject producerAlarmJson = JSON.parseObject(cluster.getServer());
         String topic = producerAlarmJson.getString("topic");
         String[] speeds = producerAlarmJson.getString("speed").split(",");
+        String duration_tmp = producerAlarmJson.getString("duration"); // unit is minute
+        int duration = 1;
+        if(duration_tmp == null){
+            duration = 1;
+        }
+        try{
+            duration = Integer.valueOf(duration_tmp).intValue();
+        }catch (NumberFormatException e){
+            throw new RuntimeException(e);
+        }
+
         long startSpeed = 0L;
         long endSpeed = 0L;
         if (speeds.length == 2) {
@@ -55,6 +66,7 @@ public class ProducerClusterStrategy implements ClusterStrategy {
         producerSpeedParams.put("cluster", cluster.getCluster());
         producerSpeedParams.put("topic", topic);
         producerSpeedParams.put("stime", CalendarUtils.getCustomDate("yyyyMMdd"));
+        producerSpeedParams.put("duration", duration);
         List<TopicLogSize> topicLogSizes = alertService.queryTopicProducerByAlarm(producerSpeedParams);
         long realSpeed = 0;
         if (topicLogSizes != null && topicLogSizes.size() > 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
         <project.version>3.0.1</project.version>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
     <modules>


### PR DESCRIPTION
currently user can config producer speed alarm base on latest one minute. if the alarm can be config base on configurable duration will be more usefull.
1、default is one minute
2、more than one minute is ok